### PR TITLE
feat: add components to oBerry

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,8 +482,8 @@ oBerry uses web components under the hood for creating reusable components:
 ```ts
 import { $ref, $component } from "oberry";
 
-$component("x-counter", ({ $ }) => {
-  const count = $ref(0)
+$component("x-counter", ({ $, props }) => {
+  const count = $ref(Number(props.start ?? 0))
 
   $("#counter").bind(count)
 
@@ -493,7 +493,7 @@ $component("x-counter", ({ $ }) => {
   })
 
   return `
-    <h1 id="counter">0</h1>
+    <h1 id="counter"></h1>
     <button id="btn">+</button>
   `
 })
@@ -502,7 +502,7 @@ $component("x-counter", ({ $ }) => {
 And in html:
 
 ```html
-<x-counter></x-counter>
+<x-counter start="10"></x-counter>
 ```
 
 ### Plugins

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ It gives you a **modern**, **reactive**, **jQuery-like** API without needing a b
 With oBerry, you can:
 
 - manipulate the DOM with a clean, chainable API
-- use built-in fine-grained reactivity (no external state library)
-- build small-to-medium UI features without framework overhead
+- use built-in fine-grained **reactivity** (no external state library)
+- use **components** without a framework overhead
 - write TypeScript-first right out of the box
 
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,36 @@ name('John'); // Input shows 'John'
 // User types 'Jane' -> name() returns 'Jane'
 ```
 
+### Components
+
+oBerry uses web components under the hood for creating reusable components:
+
+```ts
+import { $ref, $component } from "oberry";
+
+$component("x-counter", ({ $ }) => {
+  const count = $ref(0)
+
+  $("#counter").bind(count)
+
+  $("#btn").on("click", () => {
+    count(prev => prev + 1)
+    console.log(count())
+  })
+
+  return `
+    <h1 id="counter">0</h1>
+    <button id="btn">+</button>
+  `
+})
+```
+
+And in html:
+
+```html
+<x-counter></x-counter>
+```
+
 ### Plugins
 
 ```js

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,39 +1,44 @@
-import { $ as globalSelector } from "./selector";
-import { ElementWrapper } from "./wrapper";
 import { $effectScope } from "./reactivity";
+import type { $ as globalSelector } from "./selector";
+import { ElementWrapper } from "./wrapper";
 
 export interface ComponentContext {
-  $: typeof globalSelector
+	$: typeof globalSelector;
 }
 
-export const $component = (name: string, fn: (ctx: ComponentContext) => string) => {
-  customElements.define(
-    name,
-    class extends HTMLElement {
-      private _stopScope: (() => void) | null = null;
+export const $component = (
+	name: string,
+	fn: (ctx: ComponentContext) => string,
+) => {
+	customElements.define(
+		name,
+		class extends HTMLElement {
+			private _stopScope: (() => void) | null = null;
 
-      connectedCallback() {
-        const shadow = this.attachShadow({ mode: "open" });
+			connectedCallback() {
+				const shadow = this.attachShadow({ mode: "open" });
 
-        // dry run with noop $ — just to get the template string
-        const noop = () => new ElementWrapper<HTMLElement>([]);
-        shadow.innerHTML = fn({ $: noop as unknown as typeof globalSelector });
+				// dry run with noop $ — just to get the template string
+				const noop = () => new ElementWrapper<HTMLElement>([]);
+				shadow.innerHTML = fn({ $: noop as unknown as typeof globalSelector });
 
-        // real DOM exists, wire up all reactivity inside the scope
-        const scopedSelector = <T extends HTMLElement = HTMLElement>(
-          selector: string
-        ): ElementWrapper<T> =>
-          new ElementWrapper<T>(Array.from(shadow.querySelectorAll<T>(selector)));
+				// real DOM exists, wire up all reactivity inside the scope
+				const scopedSelector = <T extends HTMLElement = HTMLElement>(
+					selector: string,
+				): ElementWrapper<T> =>
+					new ElementWrapper<T>(
+						Array.from(shadow.querySelectorAll<T>(selector)),
+					);
 
-        this._stopScope = $effectScope(() => {
-          fn({ $: scopedSelector as typeof globalSelector });
-        });
-      }
+				this._stopScope = $effectScope(() => {
+					fn({ $: scopedSelector as typeof globalSelector });
+				});
+			}
 
-      disconnectedCallback() {
-        this._stopScope?.();
-        this._stopScope = null;
-      }
-    }
-  );
+			disconnectedCallback() {
+				this._stopScope?.();
+				this._stopScope = null;
+			}
+		},
+	);
 };

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,0 +1,39 @@
+import { $ as globalSelector } from "./selector";
+import { ElementWrapper } from "./wrapper";
+import { $effectScope } from "./reactivity";
+
+export interface ComponentContext {
+  $: typeof globalSelector
+}
+
+export const $component = (name: string, fn: (ctx: ComponentContext) => string) => {
+  customElements.define(
+    name,
+    class extends HTMLElement {
+      private _stopScope: (() => void) | null = null;
+
+      connectedCallback() {
+        const shadow = this.attachShadow({ mode: "open" });
+
+        // dry run with noop $ — just to get the template string
+        const noop = () => new ElementWrapper<HTMLElement>([]);
+        shadow.innerHTML = fn({ $: noop as unknown as typeof globalSelector });
+
+        // real DOM exists, wire up all reactivity inside the scope
+        const scopedSelector = <T extends HTMLElement = HTMLElement>(
+          selector: string
+        ): ElementWrapper<T> =>
+          new ElementWrapper<T>(Array.from(shadow.querySelectorAll<T>(selector)));
+
+        this._stopScope = $effectScope(() => {
+          fn({ $: scopedSelector as typeof globalSelector });
+        });
+      }
+
+      disconnectedCallback() {
+        this._stopScope?.();
+        this._stopScope = null;
+      }
+    }
+  );
+};

--- a/src/component.ts
+++ b/src/component.ts
@@ -27,7 +27,7 @@ export const $component = (
 			}
 
 			private ensureShadow(): ShadowRoot {
-				return this.shadowRoot ?? this.attachShadow({ mode: "open" })
+				return this.shadowRoot ?? this.attachShadow({ mode: "open" });
 			}
 
 			private renderTemplate(shadow: ShadowRoot) {

--- a/src/component.ts
+++ b/src/component.ts
@@ -16,13 +16,25 @@ export const $component = (
 			private _stopScope: (() => void) | null = null;
 
 			connectedCallback() {
-				const shadow = this.attachShadow({ mode: "open" });
+				const shadow = this.ensureShadow();
+				this.renderTemplate(shadow);
+				this.startScope(shadow);
+			}
 
-				// dry run with noop $ — just to get the template string
-				const noop = () => new ElementWrapper<HTMLElement>([]);
-				shadow.innerHTML = fn({ $: noop as unknown as typeof globalSelector });
+			disconnectedCallback() {
+				this._stopScope?.();
+				this._stopScope = null;
+			}
 
-				// real DOM exists, wire up all reactivity inside the scope
+			private ensureShadow(): ShadowRoot {
+				return this.shadowRoot ?? this.attachShadow({ mode: "open" })
+			}
+
+			private renderTemplate(shadow: ShadowRoot) {
+				shadow.innerHTML = fn({ $: () => new ElementWrapper([]) } as any);
+			}
+
+			private startScope(shadow: ShadowRoot) {
 				const scopedSelector = <T extends HTMLElement = HTMLElement>(
 					selector: string,
 				): ElementWrapper<T> =>
@@ -33,11 +45,6 @@ export const $component = (
 				this._stopScope = $effectScope(() => {
 					fn({ $: scopedSelector as typeof globalSelector });
 				});
-			}
-
-			disconnectedCallback() {
-				this._stopScope?.();
-				this._stopScope = null;
 			}
 		},
 	);

--- a/src/component.ts
+++ b/src/component.ts
@@ -3,49 +3,72 @@ import type { $ as globalSelector } from "./selector";
 import { ElementWrapper } from "./wrapper";
 
 export interface ComponentContext {
-	$: typeof globalSelector;
+  $: typeof globalSelector;
+  props: Record<string, string>;
 }
 
 export const $component = (
-	name: string,
-	fn: (ctx: ComponentContext) => string,
+  name: string,
+  fn: (ctx: ComponentContext) => string,
 ) => {
-	customElements.define(
-		name,
-		class extends HTMLElement {
-			private _stopScope: (() => void) | null = null;
+  customElements.define(
+    name,
+    class extends HTMLElement {
+      private _stopScope: (() => void) | null = null;
+      private _observer: MutationObserver | null = null;
 
-			connectedCallback() {
-				const shadow = this.ensureShadow();
-				this.renderTemplate(shadow);
-				this.startScope(shadow);
-			}
+      connectedCallback() {
+        this.mount();
+        this._observer = new MutationObserver(() => {
+          this.unmount();
+          this.mount();
+        });
+        this._observer.observe(this, { attributes: true });
+      }
 
-			disconnectedCallback() {
-				this._stopScope?.();
-				this._stopScope = null;
-			}
+      disconnectedCallback() {
+        this.unmount();
+        this._observer?.disconnect();
+        this._observer = null;
+      }
 
-			private ensureShadow(): ShadowRoot {
-				return this.shadowRoot ?? this.attachShadow({ mode: "open" });
-			}
+      private mount() {
+        const shadow = this.ensureShadow();
+        const props = this.getProps();
+        this.render(shadow, props);
+        this.startScope(shadow, props);
+      }
 
-			private renderTemplate(shadow: ShadowRoot) {
-				shadow.innerHTML = fn({ $: () => new ElementWrapper([]) } as any);
-			}
+      private unmount() {
+        this._stopScope?.();
+        this._stopScope = null;
+      }
 
-			private startScope(shadow: ShadowRoot) {
-				const scopedSelector = <T extends HTMLElement = HTMLElement>(
-					selector: string,
-				): ElementWrapper<T> =>
-					new ElementWrapper<T>(
-						Array.from(shadow.querySelectorAll<T>(selector)),
-					);
+      private getProps(): Record<string, string> {
+        return Object.fromEntries(
+          Array.from(this.attributes).map(attr => [attr.name, attr.value])
+        );
+      }
 
-				this._stopScope = $effectScope(() => {
-					fn({ $: scopedSelector as typeof globalSelector });
-				});
-			}
-		},
-	);
+      private ensureShadow(): ShadowRoot {
+        return this.shadowRoot ?? this.attachShadow({ mode: "open" });
+      }
+
+      private render(shadow: ShadowRoot, props: Record<string, string>) {
+        shadow.innerHTML = fn({ $: () => new ElementWrapper([]), props });
+      }
+
+      private startScope(shadow: ShadowRoot, props: Record<string, string>) {
+        const scopedSelector = <T extends HTMLElement = HTMLElement>(
+          selector: string,
+        ): ElementWrapper<T> =>
+          new ElementWrapper<T>(Array.from(shadow.querySelectorAll<T>(selector)));
+
+        this._stopScope = $effectScope(() => {
+          fn({ $: scopedSelector as typeof globalSelector, props });
+        });
+      }
+    },
+  );
 };
+

--- a/src/component.ts
+++ b/src/component.ts
@@ -3,72 +3,73 @@ import type { $ as globalSelector } from "./selector";
 import { ElementWrapper } from "./wrapper";
 
 export interface ComponentContext {
-  $: typeof globalSelector;
-  props: Record<string, string>;
+	$: typeof globalSelector;
+	props: Record<string, string>;
 }
 
 export const $component = (
-  name: string,
-  fn: (ctx: ComponentContext) => string,
+	name: string,
+	fn: (ctx: ComponentContext) => string,
 ) => {
-  customElements.define(
-    name,
-    class extends HTMLElement {
-      private _stopScope: (() => void) | null = null;
-      private _observer: MutationObserver | null = null;
+	customElements.define(
+		name,
+		class extends HTMLElement {
+			private _stopScope: (() => void) | null = null;
+			private _observer: MutationObserver | null = null;
 
-      connectedCallback() {
-        this.mount();
-        this._observer = new MutationObserver(() => {
-          this.unmount();
-          this.mount();
-        });
-        this._observer.observe(this, { attributes: true });
-      }
+			connectedCallback() {
+				this.mount();
+				this._observer = new MutationObserver(() => {
+					this.unmount();
+					this.mount();
+				});
+				this._observer.observe(this, { attributes: true });
+			}
 
-      disconnectedCallback() {
-        this.unmount();
-        this._observer?.disconnect();
-        this._observer = null;
-      }
+			disconnectedCallback() {
+				this.unmount();
+				this._observer?.disconnect();
+				this._observer = null;
+			}
 
-      private mount() {
-        const shadow = this.ensureShadow();
-        const props = this.getProps();
-        this.render(shadow, props);
-        this.startScope(shadow, props);
-      }
+			private mount() {
+				const shadow = this.ensureShadow();
+				const props = this.getProps();
+				this.render(shadow, props);
+				this.startScope(shadow, props);
+			}
 
-      private unmount() {
-        this._stopScope?.();
-        this._stopScope = null;
-      }
+			private unmount() {
+				this._stopScope?.();
+				this._stopScope = null;
+			}
 
-      private getProps(): Record<string, string> {
-        return Object.fromEntries(
-          Array.from(this.attributes).map(attr => [attr.name, attr.value])
-        );
-      }
+			private getProps(): Record<string, string> {
+				return Object.fromEntries(
+					Array.from(this.attributes).map((attr) => [attr.name, attr.value]),
+				);
+			}
 
-      private ensureShadow(): ShadowRoot {
-        return this.shadowRoot ?? this.attachShadow({ mode: "open" });
-      }
+			private ensureShadow(): ShadowRoot {
+				return this.shadowRoot ?? this.attachShadow({ mode: "open" });
+			}
 
-      private render(shadow: ShadowRoot, props: Record<string, string>) {
-        shadow.innerHTML = fn({ $: () => new ElementWrapper([]), props });
-      }
+			private render(shadow: ShadowRoot, props: Record<string, string>) {
+				shadow.innerHTML = fn({ $: () => new ElementWrapper([]), props });
+			}
 
-      private startScope(shadow: ShadowRoot, props: Record<string, string>) {
-        const scopedSelector = <T extends HTMLElement = HTMLElement>(
-          selector: string,
-        ): ElementWrapper<T> =>
-          new ElementWrapper<T>(Array.from(shadow.querySelectorAll<T>(selector)));
+			private startScope(shadow: ShadowRoot, props: Record<string, string>) {
+				const scopedSelector = <T extends HTMLElement = HTMLElement>(
+					selector: string,
+				): ElementWrapper<T> =>
+					new ElementWrapper<T>(
+						Array.from(shadow.querySelectorAll<T>(selector)),
+					);
 
-        this._stopScope = $effectScope(() => {
-          fn({ $: scopedSelector as typeof globalSelector, props });
-        });
-      }
-    },
-  );
+				this._stopScope = $effectScope(() => {
+					fn({ $: scopedSelector as typeof globalSelector, props });
+				});
+			}
+		},
+	);
 };
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
+export { $component } from "./component";
 export { $new } from "./creator";
 export { Plugin, use } from "./plugins";
 export type { Ref } from "./reactivity";
 export { $computed, $effect, $effectScope, $ref } from "./reactivity";
 export { $ } from "./selector";
-export { $component } from "./component";
 export type { ElementWrapper } from "./wrapper";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,5 @@ export { Plugin, use } from "./plugins";
 export type { Ref } from "./reactivity";
 export { $computed, $effect, $effectScope, $ref } from "./reactivity";
 export { $ } from "./selector";
+export { $component } from "./component";
 export type { ElementWrapper } from "./wrapper";


### PR DESCRIPTION
Add a `$component` function for creating reusable components, powered by web components.

Usage:
```ts
import { $ref, $component } from "oberry";

$component("x-counter", ({ $, props }) => {
  const count = $ref(Number(props.start ?? 0))

  $("#counter").bind(count)

  $("#btn").on("click", () => {
    count(prev => prev + 1)
    console.log(count())
  })

  return `
    <h1 id="counter"></h1>
    <button id="btn">+</button>
  `
})
```

```html
<x-counter start="10"> </x-counter>