### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/oberryjs/oBerry/security/code-scanning/5](https://github.com/oberryjs/oBerry/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so the token scope is documented and restricted.  
Best single fix without changing behavior: add workflow-level permissions with `contents: read` (the minimal baseline recommended by CodeQL/GitHub for checkout and read operations). This applies to all jobs unless overridden and keeps functionality intact for the current single `test` job.

**File to change:** `.github/workflows/test.yml`  
**Region:** between the `on:` trigger block and `jobs:` (after line 7 in the provided snippet).  
**No imports/dependencies/methods** are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
