### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/oberryjs/oBerry/security/code-scanning/2](https://github.com/oberryjs/oBerry/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root so it applies to all jobs (including `lint`) unless overridden. For this workflow, `contents: read` is the minimal and appropriate permission, since it needs to checkout repository contents and run local linting without writes.

Best single fix (no functionality change):
- File: `.github/workflows/lint.yml`
- Region: directly after `name: Lint` and before `on:`
- Add:
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
